### PR TITLE
새로운 폼 유효성 검증 추가 (#126)

### DIFF
--- a/frontend/src/hooks/useNewForm/useFormErrors.tsx
+++ b/frontend/src/hooks/useNewForm/useFormErrors.tsx
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+interface FormErrors {
+  [key: string]: string;
+}
+
+const useFormErrors = <T extends object>(form: T) => {
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  return { errors, setErrors };
+};
+export default useFormErrors;

--- a/frontend/src/hooks/useNewForm/useNewForm.tsx
+++ b/frontend/src/hooks/useNewForm/useNewForm.tsx
@@ -1,0 +1,37 @@
+import { ChangeEvent, useEffect, useState } from 'react';
+import useValidateForm from './useValidateForm';
+import { ValidateSchema } from '@/types/validate';
+
+const useNewForm = <T extends { [key: string]: any }>(
+  initialValues: T,
+  validationSchema?: ValidateSchema,
+  serverData?: object,
+) => {
+  const [form, setForm] = useState(initialValues);
+  const { errors, validateAll, validate } = useValidateForm(
+    form,
+    validationSchema!,
+  );
+  /** Form 초기화 */
+  if (serverData)
+    useEffect(() => {
+      setForm((prev) => ({ ...prev, serverData }));
+    }, [serverData]);
+
+  /** form value handler */
+  const handleFormValueChange = <T,>(
+    e:
+      | ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+      | { name: string; value: T },
+  ) => {
+    const target = 'target' in e ? e.target : e;
+    const { name, value } = target;
+
+    setForm((prev) => ({ ...prev, [name]: value }));
+    validate(name!, value);
+  };
+
+  return { form, setForm, handleFormValueChange, errors, validateAll };
+};
+
+export default useNewForm;

--- a/frontend/src/hooks/useNewForm/useValidateForm.tsx
+++ b/frontend/src/hooks/useNewForm/useValidateForm.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import useFormErrors from './useFormErrors';
+import { invalid } from './validate';
+import { ValidateSchema, ValidateSchemaValue } from '@/types/validate';
+
+const useValidateForm = <T extends { [key: string]: any }>(
+  form: T,
+  validateSchema: ValidateSchema,
+) => {
+  const copied = { ...validateSchema };
+  const { errors, setErrors } = useFormErrors(form);
+  const validateAll = () => {
+    Object.keys(copied).forEach((k: string) => {
+      validate(k, form[k]);
+    });
+  };
+
+  const validate = (k: string, value: any) => {
+    const schema = validateSchema[k];
+    const errorMessage = invalid(value, schema as ValidateSchemaValue);
+
+    if (errorMessage) {
+      setErrors((prev) => ({ ...prev!, [k as string]: errorMessage! }));
+
+      return;
+    }
+
+    setErrors((prev) => {
+      const copied = { ...prev };
+      delete copied[k];
+      return copied;
+    });
+  };
+
+  return { validate, validateAll, errors };
+};
+
+export default useValidateForm;

--- a/frontend/src/hooks/useNewForm/validate.ts
+++ b/frontend/src/hooks/useNewForm/validate.ts
@@ -1,0 +1,54 @@
+import { ValidateSchemaValue } from "@/types/validate";
+import useFormErrors from "./useFormErrors";
+ 
+export const invalid = <T,>(value:T, validateInfo:ValidateSchemaValue)=>{
+  const v = validate(value);
+  const {required, min, max, minLength} =validateInfo;
+
+  let errorMessage = null;
+  
+  if(required){
+    if(!v.isRequired()){
+      errorMessage= required.message;
+    }
+    
+  }  
+
+  if(min){
+    if(!v.isMin(Number(min.value!))){
+      errorMessage=  min.message;
+    }
+    
+  }  
+  if(max){
+    if(!v.isMax(max.value!)){
+      errorMessage= max.message;
+    }
+    
+  }  
+  if(minLength){
+    if(!v.isMinLength(minLength.value!)){
+      errorMessage= minLength.message;
+    }
+    
+  } 
+  return errorMessage; 
+}
+
+  export const validate = <T,>(value: T) => {
+    return {
+      isRequired: () =>
+        value !== null &&
+        value !== undefined &&
+        ((typeof value === 'string' && value !== '') ||
+          (Array.isArray(value) && value.length > 0)),
+      isRegexCorrect: (regex: RegExp) => new RegExp(regex!).test(value as string),
+      isMin: (min: number) => Number(value) > Number(min)!,
+      isMax: (max: number) => typeof value === 'number' && value < max!,
+      isMinLength: (minLength: number) =>
+        typeof value === 'string' && value.length > minLength,
+    };
+  };
+
+
+  


### PR DESCRIPTION
* FEAT:직무 선택 모달 반응형 디자인 추가

* FEAT:SideBar 에서 페이지 이동시 닫히지 않도록 수정

* 웹 에서는 닫히면 안되지만, 닫히는 이슈 때문에 우선 수정

* FEAT:SelectModal 버튼 들 스타일 수정

* FEAT:채널톡 추가

* RENAME:접근성 플로팅 버튼 네이밍 수정

* FEAT:SideBar 애니메이션 추가

* Modal.styled.tsx 의 fadeIn export

* FEAT:직무 순위, 관심 멘토 API 유저가 아닐 시, 호출하지 않도록 수정

* FIX:미반영된 변경사항 반영

* FEAT:오늘의 멘토링 데이터 없을 시 문구 및 이미지 수정, 오늘의 멘토링 커스텀 훅 추가

* useTodayMentorings

* FIX:오늘의 멘토링 컴포넌트 렌더링 조건 수정

* query 결과가 isSuccess 일경우 컴포넌트가 렌더링 되도록 수정

* FEAT:취업 직무 순위 데이터 없을 시, 각 케이스에 맞는 페이지로 이동하는 버튼 추가

* FEAT:날짜 지난 멘토링 신청 보이지 않도록 수정

* 알림, 멘토링 신청 페이지 에서 보이지 않도록 수정
* GetMentoringAppliesResponseData 타입 에 datePassed, mentoringStatus 추가
* useMentoringApplies 커스텀 훅 추가
   - 날짜가 지나거나, 신청 상태가 완료 혹은 거절인 신청은 필터링

* FEAT:최신 버전의 useForm 으로 모든 폼 커스텀훅 대체

* FIX:회원가입 완료 후, 프로필 작성 이동 버튼 URL 수정

* FEAT:theme const assertion 설정

* FIX:사용되지 않는 함수, combineValuesWithValidation 제거

* SETTING:vscode setting

* FEAT:새로운 폼 입력, 폼 유효성 검증 커스텀 훅 추가

* 폼 유효성 검증 실패 시, 에러 메세지 출력 기능 추가
* 폼, 유효성 검증, 에러 관심사 분리
* 유효성 검증 관련 타입 추가

* BUILD:빌드 에러 수정

* RENAME:UI 컴포넌트 props 타입 네이밍 변경

* FIX:Input onChange 이벤트 매개변수 타입 지정

* FEAT:새로운 폼 입력, 폼 유효성 검증 커스텀 훅 추가

* 폼 유효성 검증 실패 시, 에러 메세지 출력 기능 추가
* 폼, 유효성 검증, 에러 관심사 분리
* 유효성 검증 관련 타입 추가