### PR TITLE
개선작업 (#127)

### DIFF
--- a/frontend/src/hooks/useNewForm/useFormErrors.tsx
+++ b/frontend/src/hooks/useNewForm/useFormErrors.tsx
@@ -7,6 +7,10 @@ interface FormErrors {
 const useFormErrors = <T extends object>(form: T) => {
   const [errors, setErrors] = useState<FormErrors>({});
 
-  return { errors, setErrors };
+  const isInvalid = (key: string) => {
+    return key in errors;
+  };
+
+  return { errors, setErrors, isInvalid };
 };
 export default useFormErrors;

--- a/frontend/src/hooks/useNewForm/useNewForm.tsx
+++ b/frontend/src/hooks/useNewForm/useNewForm.tsx
@@ -8,15 +8,28 @@ const useNewForm = <T extends { [key: string]: any }>(
   serverData?: object,
 ) => {
   const [form, setForm] = useState(initialValues);
-  const { errors, validateAll, validate } = useValidateForm(
+  const { errors, validateAll, validate, isInvalid } = useValidateForm(
     form,
     validationSchema!,
   );
   /** Form 초기화 */
-  if (serverData)
-    useEffect(() => {
-      setForm((prev) => ({ ...prev, serverData }));
-    }, [serverData]);
+  const setFormFromServerData = (data: object) => {
+    const formValues = { ...form };
+    Object.keys(data).forEach((key) => {
+      if (Object.hasOwn(form, key)) {
+        Object.assign(formValues, {
+          ...formValues,
+          [key]: data[key as keyof typeof data],
+        });
+      }
+    });
+    return formValues;
+  };
+  useEffect(() => {
+    if (serverData) {
+      setForm(setFormFromServerData(serverData!));
+    }
+  }, [serverData]);
 
   /** form value handler */
   const handleFormValueChange = <T,>(
@@ -31,7 +44,15 @@ const useNewForm = <T extends { [key: string]: any }>(
     validate(name!, value);
   };
 
-  return { form, setForm, handleFormValueChange, errors, validateAll };
+  return {
+    form,
+    setForm,
+    handleFormValueChange,
+    errors,
+    validateAll,
+    isInvalid,
+  };
+
 };
 
 export default useNewForm;

--- a/frontend/src/hooks/useNewForm/useValidateForm.tsx
+++ b/frontend/src/hooks/useNewForm/useValidateForm.tsx
@@ -8,7 +8,7 @@ const useValidateForm = <T extends { [key: string]: any }>(
   validateSchema: ValidateSchema,
 ) => {
   const copied = { ...validateSchema };
-  const { errors, setErrors } = useFormErrors(form);
+  const { errors, setErrors, isInvalid } = useFormErrors(form);
   const validateAll = () => {
     Object.keys(copied).forEach((k: string) => {
       validate(k, form[k]);
@@ -31,8 +31,7 @@ const useValidateForm = <T extends { [key: string]: any }>(
       return copied;
     });
   };
-
-  return { validate, validateAll, errors };
+  return { validate, validateAll, errors, isInvalid };
 };
 
 export default useValidateForm;


### PR DESCRIPTION
* FEAT:직무 선택 모달 반응형 디자인 추가

* FEAT:SideBar 에서 페이지 이동시 닫히지 않도록 수정

* 웹 에서는 닫히면 안되지만, 닫히는 이슈 때문에 우선 수정

* FEAT:SelectModal 버튼 들 스타일 수정

* FEAT:채널톡 추가

* RENAME:접근성 플로팅 버튼 네이밍 수정

* FEAT:SideBar 애니메이션 추가

* Modal.styled.tsx 의 fadeIn export

* FEAT:직무 순위, 관심 멘토 API 유저가 아닐 시, 호출하지 않도록 수정

* FIX:미반영된 변경사항 반영

* FEAT:오늘의 멘토링 데이터 없을 시 문구 및 이미지 수정, 오늘의 멘토링 커스텀 훅 추가

* useTodayMentorings

* FIX:오늘의 멘토링 컴포넌트 렌더링 조건 수정

* query 결과가 isSuccess 일경우 컴포넌트가 렌더링 되도록 수정

* FEAT:취업 직무 순위 데이터 없을 시, 각 케이스에 맞는 페이지로 이동하는 버튼 추가

* FEAT:날짜 지난 멘토링 신청 보이지 않도록 수정

* 알림, 멘토링 신청 페이지 에서 보이지 않도록 수정
* GetMentoringAppliesResponseData 타입 에 datePassed, mentoringStatus 추가
* useMentoringApplies 커스텀 훅 추가
   - 날짜가 지나거나, 신청 상태가 완료 혹은 거절인 신청은 필터링

* FEAT:최신 버전의 useForm 으로 모든 폼 커스텀훅 대체

* FIX:회원가입 완료 후, 프로필 작성 이동 버튼 URL 수정

* FEAT:theme const assertion 설정

* FIX:사용되지 않는 함수, combineValuesWithValidation 제거

* SETTING:vscode setting

* FEAT:새로운 폼 입력, 폼 유효성 검증 커스텀 훅 추가

* 폼 유효성 검증 실패 시, 에러 메세지 출력 기능 추가
* 폼, 유효성 검증, 에러 관심사 분리
* 유효성 검증 관련 타입 추가

* BUILD:빌드 에러 수정

* RENAME:UI 컴포넌트 props 타입 네이밍 변경

* FIX:Input onChange 이벤트 매개변수 타입 지정

* FEAT:새로운 폼 입력, 폼 유효성 검증 커스텀 훅 추가

* 폼 유효성 검증 실패 시, 에러 메세지 출력 기능 추가
* 폼, 유효성 검증, 에러 관심사 분리
* 유효성 검증 관련 타입 추가

* FEAT:폼 에러 확인 함수 추가 및 새로운 폼 커스텀 훅 profileForm 페이지에 적용

* useFormErrors
   - isInvalid 추가